### PR TITLE
Add Disc() and TagSize() methods to GenericTag

### DIFF
--- a/taglib/id3/id3v23.go
+++ b/taglib/id3/id3v23.go
@@ -90,6 +90,18 @@ func (t *Id3v23Tag) Track() uint32 {
 	return uint32(track)
 }
 
+func (t *Id3v23Tag) Disc() uint32 {
+	disc, err := parseLeadingInt(getSimpleId3v23TextFrame(t.Frames["TPOS"]))
+	if err != nil {
+		return 0
+	}
+	return uint32(disc)
+}
+
+func (t *Id3v23Tag) TagSize() uint32 {
+	return 10 + t.Header.Size
+}
+
 type Id3v23Header struct {
 	MinorVersion byte
 	Flags        Id3v23HeaderFlags

--- a/taglib/id3/id3v24.go
+++ b/taglib/id3/id3v24.go
@@ -90,6 +90,18 @@ func (t *Id3v24Tag) Track() uint32 {
 	return uint32(track)
 }
 
+func (t *Id3v24Tag) Disc() uint32 {
+	disc, err := parseLeadingInt(getSimpleId3v24TextFrame(t.Frames["TPOS"]))
+	if err != nil {
+		return 0
+	}
+	return uint32(disc)
+}
+
+func (t *Id3v24Tag) TagSize() uint32 {
+	return 10 + t.Header.Size
+}
+
 type Id3v24Header struct {
 	MinorVersion byte
 	Flags        Id3v24HeaderFlags

--- a/taglib/taglib.go
+++ b/taglib/taglib.go
@@ -40,6 +40,11 @@ type GenericTag interface {
 	Genre() string
 	Year() time.Time
 	Track() uint32
+	Disc() uint32
+
+	// Returns the total size of the header and tags in the file, i.e.
+	// the position at which audio data starts.
+	TagSize() uint32
 }
 
 // Decode reads r and determines which tag format the data is in, if

--- a/taglib/taglib_test.go
+++ b/taglib/taglib_test.go
@@ -25,8 +25,11 @@ func ExampleDecode() {
 	if err != nil {
 		panic(err)
 	}
-
-	tag, err := Decode(f)
+	fi, err := f.Stat()
+	if err != nil {
+		panic(err)
+	}
+	tag, err := Decode(f, fi.Size())
 	if err != nil {
 		panic(err)
 	}
@@ -36,6 +39,7 @@ func ExampleDecode() {
 	fmt.Println("Album:", tag.Album())
 	fmt.Println("Genre:", tag.Genre())
 	fmt.Println("Year:", tag.Year())
+	fmt.Println("Disc:", tag.Disc())
 	fmt.Println("Track:", tag.Track())
 
 	// Output:
@@ -44,5 +48,6 @@ func ExampleDecode() {
 	// Album: Test Album
 	// Genre: Classical
 	// Year: 2008-01-01 00:00:00 +0000 UTC
+	// Disc: 3
 	// Track: 7
 }


### PR DESCRIPTION
Add methods for getting the disc number and the total size
of the header and tag data (useful when trying to generate a
hash of only the unchanging audio portion of a file).

Also fix not-compiling examples.
