### PR TITLE
Add CustomFrames() to GenericTag

### DIFF
--- a/taglib/id3/id3v23.go
+++ b/taglib/id3/id3v23.go
@@ -98,6 +98,19 @@ func (t *Id3v23Tag) Disc() uint32 {
 	return uint32(disc)
 }
 
+func (t *Id3v23Tag) CustomFrames() map[string]string {
+	info := make(map[string]string)
+	for _, frame := range t.Frames["TXXX"] {
+		// See http://id3.org/id3v2.3.0#User_defined_text_information_frame.
+		// TXXX frames contain NUL-separated descriptions and values.
+		parts, err := GetId3v23TextIdentificationFrame(frame)
+		if err == nil && len(parts) == 2 {
+			info[parts[0]] = parts[1]
+		}
+	}
+	return info
+}
+
 func (t *Id3v23Tag) TagSize() uint32 {
 	return 10 + t.Header.Size
 }

--- a/taglib/id3/id3v24.go
+++ b/taglib/id3/id3v24.go
@@ -98,6 +98,20 @@ func (t *Id3v24Tag) Disc() uint32 {
 	return uint32(disc)
 }
 
+func (t *Id3v24Tag) CustomFrames() map[string]string {
+	info := make(map[string]string)
+	for _, frame := range t.Frames["TXXX"] {
+		// See "4.2.6. User defined text information frame" at
+		// http://id3.org/id3v2.4.0-frames. TXXX frames contain
+		// NUL-separated descriptions and values.
+		parts, err := GetId3v24TextIdentificationFrame(frame)
+		if err == nil && len(parts) == 2 {
+			info[parts[0]] = parts[1]
+		}
+	}
+	return info
+}
+
 func (t *Id3v24Tag) TagSize() uint32 {
 	return 10 + t.Header.Size
 }

--- a/taglib/taglib.go
+++ b/taglib/taglib.go
@@ -42,8 +42,13 @@ type GenericTag interface {
 	Track() uint32
 	Disc() uint32
 
-	// Returns the total size of the header and tags in the file, i.e.
-	// the position at which audio data starts.
+	// CustomFrames returns non-standard, user-defined frames as a map from
+	// descriptions (e.g. "PERFORMER", "MusicBrainz Album Id", etc.) to
+	// values.
+	CustomFrames() map[string]string
+
+	// TagSize returns the total size of the tag's header and frames,
+	// i.e. the position at which audio data starts.
 	TagSize() uint32
 }
 

--- a/taglib/taglib_test.go
+++ b/taglib/taglib_test.go
@@ -41,6 +41,7 @@ func ExampleDecode() {
 	fmt.Println("Year:", tag.Year())
 	fmt.Println("Disc:", tag.Disc())
 	fmt.Println("Track:", tag.Track())
+	fmt.Println("Performer:", tag.CustomFrames()["PERFORMER"])
 
 	// Output:
 	// Title: Test Name
@@ -50,4 +51,5 @@ func ExampleDecode() {
 	// Year: 2008-01-01 00:00:00 +0000 UTC
 	// Disc: 3
 	// Track: 7
+	// Performer: Somebody
 }


### PR DESCRIPTION
Add a method for getting user-defined text information
frames, a.k.a. TXXX. These are commonly used to store
MusicBrainz IDs, among other things.

Also improve wording of TagSize()'s comment.
