### PR TITLE
Use TYER instead of TDRC for year on v2.3

### DIFF
--- a/taglib/id3/id3v23.go
+++ b/taglib/id3/id3v23.go
@@ -69,12 +69,12 @@ func (t *Id3v23Tag) Genre() string {
 }
 
 func (t *Id3v23Tag) Year() time.Time {
-	yearStr := getSimpleId3v23TextFrame(t.Frames["TDRC"])
-	if len(yearStr) < 4 {
+	yearStr := getSimpleId3v23TextFrame(t.Frames["TYER"])
+	if len(yearStr) != 4 {
 		return time.Time{}
 	}
 
-	yearInt, err := strconv.Atoi(yearStr[0:4])
+	yearInt, err := strconv.Atoi(yearStr)
 	if err != nil {
 		return time.Time{}
 	}


### PR DESCRIPTION
ID3 v2.3 uses separate 4-byte TYER, TDAT, and TIME frames to
store the recording time, as opposed to v2.4's unified TDRC
frame:

  http://id3.org/id3v2.3.0#Text_information_frames_-_details
  http://eyed3.nicfit.net/compliance.html
