### PR TITLE
Fixed: Frame size is encoded in base256 bytes not base128

### DIFF
--- a/taglib/id3/id3v23.go
+++ b/taglib/id3/id3v23.go
@@ -293,8 +293,8 @@ func parseId3v23FrameHeader(br *bufio.Reader) (result Id3v23FrameHeader, err err
 	idBytes, sizeBytes, flags := headerBytes[0:4], headerBytes[4:8], headerBytes[8:10]
 	result.Id = string(idBytes)
 
-	// Read the size as 4 base128 bytes.
-	result.Size = uint32(parseBase128Int(sizeBytes))
+	// Read the size as 4 base256 bytes (note this is different to the size given in the tag header)
+	result.Size = uint32(parseBase256Int(sizeBytes))
 
 	result.Flags.TagAlterPreservation = (flags[0] & (1 << 7)) != 0
 	result.Flags.FileAlterPreservation = (flags[0] & (1 << 6)) != 0

--- a/taglib/id3/id3v24.go
+++ b/taglib/id3/id3v24.go
@@ -300,8 +300,8 @@ func parseId3v24FrameHeader(br *bufio.Reader) (result Id3v24FrameHeader, err err
 	idBytes, sizeBytes, flags := headerBytes[0:4], headerBytes[4:8], headerBytes[8:10]
 	result.Id = string(idBytes)
 
-	// Read the size as 4 base128 bytes.
-	result.Size = uint32(parseBase128Int(sizeBytes))
+	// Read the size as 4 base256 bytes (note that this is different to the tag header)
+	result.Size = uint32(parseBase256Int(sizeBytes))
 
 	result.Flags.TagAlterPreservation = (flags[0] & (1 << 6)) != 0
 	result.Flags.FileAlterPreservation = (flags[0] & (1 << 5)) != 0

--- a/taglib/id3/util.go
+++ b/taglib/id3/util.go
@@ -40,6 +40,15 @@ func parseBase128Int(bytes []byte) uint64 {
 	return result
 }
 
+func parseBase256Int(bytes []byte) uint64 {
+	var result uint64
+	for _, b := range bytes {
+		result = result << 8
+		result |= uint64(b)
+	}
+	return result
+}
+
 func parseLeadingInt(s string) (int, error) {
 	var intEnd int
 	for intEnd < len(s) && '0' <= s[intEnd] && s[intEnd] <= '9' {


### PR DESCRIPTION
This would cause large frames to be incorrectly handled.
