### PR TITLE
Permit sub-4-byte padding in ID3 v2.4 tags

### DIFF
--- a/taglib/id3/id3v24.go
+++ b/taglib/id3/id3v24.go
@@ -262,7 +262,12 @@ func parseId3v24ExtendedHeader(br *bufio.Reader) (result Id3v24ExtendedHeader, e
 
 func hasId3v24Frame(br *bufio.Reader) (bool, error) {
 	data, err := br.Peek(4)
-	if err != nil {
+	if err == io.EOF {
+		// If there are fewer than 4 bytes remaining, assume that they're
+		// padding after the final frame (see section 3.3 of
+		// http://id3.org/id3v2.4.0-structure).
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
The spec permits implicit padding to be present after the
final frame. This was already handled in 4-bytes-or-longer
cases (by bailing out after seeing a 0x0 byte within the
frame ID), but an EOF error would be returned for shorter
padding.