### PR TITLE
Add UniqueFileIdentifiers() to CustomTag

### DIFF
--- a/taglib/id3/id3v23.go
+++ b/taglib/id3/id3v23.go
@@ -98,6 +98,19 @@ func (t *Id3v23Tag) Disc() uint32 {
 	return uint32(disc)
 }
 
+func (t *Id3v23Tag) UniqueFileIdentifiers() map[string]string {
+	ids := make(map[string]string)
+	for _, frame := range t.Frames["UFID"] {
+		// See http://id3.org/id3v2.3.0#Unique_file_identifier.
+		// UFID frames contain NUL-separated owners and IDs.
+		parts, err := GetId3v23UniqueFileIdentifierFrame(frame)
+		if err == nil && len(parts) == 2 {
+			ids[parts[0]] = parts[1]
+		}
+	}
+	return ids
+}
+
 func (t *Id3v23Tag) CustomFrames() map[string]string {
 	info := make(map[string]string)
 	for _, frame := range t.Frames["TXXX"] {

--- a/taglib/id3/id3v23frames.go
+++ b/taglib/id3/id3v23frames.go
@@ -17,3 +17,7 @@ package id3
 func GetId3v23TextIdentificationFrame(frame *Id3v23Frame) ([]string, error) {
 	return getTextIdentificationFrame(frame.Content)
 }
+
+func GetId3v23UniqueFileIdentifierFrame(frame *Id3v23Frame) ([]string, error) {
+	return getUniqueFileIdentifierFrame(frame.Content)
+}

--- a/taglib/id3/id3v24.go
+++ b/taglib/id3/id3v24.go
@@ -98,6 +98,19 @@ func (t *Id3v24Tag) Disc() uint32 {
 	return uint32(disc)
 }
 
+func (t *Id3v24Tag) UniqueFileIdentifiers() map[string]string {
+	ids := make(map[string]string)
+	for _, frame := range t.Frames["UFID"] {
+		// See "4.1. Unique file identifier" at http://id3.org/id3v2.4.0-frames.
+		// UFID frames contain NUL-separated owners and IDs.
+		parts, err := GetId3v24UniqueFileIdentifierFrame(frame)
+		if err == nil && len(parts) == 2 {
+			ids[parts[0]] = parts[1]
+		}
+	}
+	return ids
+}
+
 func (t *Id3v24Tag) CustomFrames() map[string]string {
 	info := make(map[string]string)
 	for _, frame := range t.Frames["TXXX"] {

--- a/taglib/id3/id3v24frames.go
+++ b/taglib/id3/id3v24frames.go
@@ -17,3 +17,7 @@ package id3
 func GetId3v24TextIdentificationFrame(frame *Id3v24Frame) ([]string, error) {
 	return getTextIdentificationFrame(frame.Content)
 }
+
+func GetId3v24UniqueFileIdentifierFrame(frame *Id3v24Frame) ([]string, error) {
+	return getUniqueFileIdentifierFrame(frame.Content)
+}

--- a/taglib/id3/util.go
+++ b/taglib/id3/util.go
@@ -57,6 +57,22 @@ func getTextIdentificationFrame(content []byte) ([]string, error) {
 	return strings.Split(normalized, string([]byte{0})), nil
 }
 
+// getUniqueFileIdentifierFrame parses a unique file identifier frame's content,
+// consisting of a bare owner string followed by NUL and the identifier itself.
+func getUniqueFileIdentifierFrame(content []byte) ([]string, error) {
+	var ownerEnd int
+	for ownerEnd < len(content) && content[ownerEnd] != 0x0 {
+		ownerEnd++
+	}
+	if ownerEnd == 0 {
+		return nil, id3v24Err("zero-length owner string")
+	}
+	if ownerEnd == len(content) {
+		return nil, id3v24Err("NUL separator not present")
+	}
+	return []string{string(content[:ownerEnd]), string(content[ownerEnd+1:])}, nil
+}
+
 // Parses a string from frame data. The first byte represents the encoding:
 //   0x01  ISO-8859-1
 //   0x02  UTF-16 w/ BOM

--- a/taglib/taglib.go
+++ b/taglib/taglib.go
@@ -39,6 +39,12 @@ type GenericTag interface {
 	Track() uint32
 	Disc() uint32
 
+	// UniqueFileIdentifiers returns a map from the URL of the owner of a
+	// database assigning unique identifiers to files (e.g.
+	// "http://musicbrainz.org") to the identifier uniquely identifying the
+	// file.
+	UniqueFileIdentifiers() map[string]string
+
 	// CustomFrames returns non-standard, user-defined frames as a map from
 	// descriptions (e.g. "PERFORMER", "MusicBrainz Album Id", etc.) to
 	// values.


### PR DESCRIPTION
Parse UFID frames in v2.3 and v2.4 tags, used to assign
unique identifiers to files.
