### PR TITLE
id3: Drop trailing NULs from text frames.

### DIFF
--- a/taglib/id3/util.go
+++ b/taglib/id3/util.go
@@ -54,6 +54,7 @@ func getTextIdentificationFrame(content []byte) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	normalized = strings.TrimRight(normalized, string([]byte{0}))
 	return strings.Split(normalized, string([]byte{0})), nil
 }
 


### PR DESCRIPTION
Picard 1.3.2 and later (at least up to 2.5.6?) appear to insert a trailing NUL at the end of frames, resulting in taglib appending a trailing space (after splitting frames on NUL and then joining with spaces). Trim trailing NULs before splitting to prevent this from occurring.