### PR TITLE
Fix out-of-bounds panic on too-small extended headers

### DIFF
--- a/taglib/id3/id3v23.go
+++ b/taglib/id3/id3v23.go
@@ -236,14 +236,17 @@ func parseId3v23ExtendedHeader(br *bufio.Reader) (result Id3v23ExtendedHeader, e
 	}
 
 	result.Size = uint32(parseBase128Int(sizeBytes))
+	if result.Size < 6 {
+		return result, fmt.Errorf("header size too small (%v)", result.Size)
+	}
 
-	headerBytes := make([]byte, result.Size)
+	headerBytes := make([]byte, 6)
 	if _, err = io.ReadFull(br, headerBytes); err != nil {
 		return
 	}
 
 	// Store the flags bytes and the size of the padding.
-	flags, paddingSize, headerBytes := headerBytes[0:2], headerBytes[2:6], headerBytes[6:]
+	flags, paddingSize := headerBytes[0:2], headerBytes[2:6]
 
 	result.Flags.CrcDataPresent = (flags[0] & (1 << 7)) != 0
 

--- a/taglib/id3/id3v24.go
+++ b/taglib/id3/id3v24.go
@@ -242,14 +242,17 @@ func parseId3v24ExtendedHeader(br *bufio.Reader) (result Id3v24ExtendedHeader, e
 	}
 
 	result.Size = uint32(parseBase128Int(sizeBytes))
+	if result.Size < 6 {
+		return result, fmt.Errorf("header size too small (%v)", result.Size)
+	}
 
-	headerBytes := make([]byte, result.Size)
+	headerBytes := make([]byte, 6)
 	if _, err = io.ReadFull(br, headerBytes); err != nil {
 		return
 	}
 
 	// Discard size and number of flags bytes, and store flags.
-	_, _, flags, headerBytes := headerBytes[:4], headerBytes[4], headerBytes[5], headerBytes[5:]
+	_, _, flags := headerBytes[:4], headerBytes[4], headerBytes[5]
 
 	result.Flags.Update = (flags & (1 << 6)) != 0
 	result.Flags.CrcDataPresent = (flags & (1 << 5)) != 0


### PR DESCRIPTION
Avoid an out-of-bounds panic in the v2.3 and v2.4 extended header parsing code when the stated header size is smaller than the minimum 6 bytes.

Also avoid reading the rest of the extended header since it's currently unused and looks like it exposes an out-of-memory DoS.