### PR TITLE
Read frame into bytes.Buffer to avoid OOM

### DIFF
--- a/taglib/id3/id3v23.go
+++ b/taglib/id3/id3v23.go
@@ -273,14 +273,14 @@ func parseId3v23Frame(br *bufio.Reader) (*Id3v23Frame, error) {
 		return nil, err
 	}
 
-	content := make([]byte, header.Size)
-	if _, err := io.ReadFull(br, content); err != nil {
+	var content bytes.Buffer
+	if _, err := io.CopyN(&content, br, int64(header.Size)); err != nil {
 		return nil, err
 	}
 
 	return &Id3v23Frame{
 		Header:  header,
-		Content: content,
+		Content: content.Bytes(),
 	}, nil
 }
 

--- a/taglib/id3/id3v24.go
+++ b/taglib/id3/id3v24.go
@@ -285,14 +285,14 @@ func parseId3v24Frame(br *bufio.Reader) (*Id3v24Frame, error) {
 		return nil, err
 	}
 
-	content := make([]byte, header.Size)
-	if _, err := io.ReadFull(br, content); err != nil {
+	var content bytes.Buffer
+	if _, err := io.CopyN(&content, br, int64(header.Size)); err != nil {
 		return nil, err
 	}
 
 	return &Id3v24Frame{
 		Header:  header,
-		Content: content,
+		Content: content.Bytes(),
 	}, nil
 }
 


### PR DESCRIPTION
Update parseId3v23Frame and parseId3v24Frame to read into a bytes.Buffer instead of preallocating the size from the header to avoid a DoS if the header states a bogus huge size.